### PR TITLE
Fix cold white level handling, implement NTC Readings

### DIFF
--- a/xiaomi_light.h
+++ b/xiaomi_light.h
@@ -29,7 +29,7 @@ class XiaomiLight : public Component, public LightOutput {
 
     ESP_LOGD("custom", "Brightness: %f", brightness);
     ESP_LOGD("custom", "Cold white fraction: %f", cw_fraction);
-    this->cold_white_->set_level(cw_fraction);
+    this->cold_white_->set_level(cw_fraction > brightness ? brightness : cw_fraction);
     if (brightness == 0) {
       this->brightness_->set_level(0);
     } else {

--- a/xiaomi_light.yaml
+++ b/xiaomi_light.yaml
@@ -1,12 +1,18 @@
 substitutions:
-  name: xiaomi-philips-light
+  hostname: xiaomi-philips-light
 
 esphome:
-  name: ${name}
+  name: $hostname
   platform: ESP8266
   board: esp_wroom_02
-  includes:
+  includes: 
     - xiaomi_light.h
+
+web_server:
+  port: 80
+
+logger:
+  level: DEBUG
 
 wifi:
   ssid: !secret wifi_ssid
@@ -15,25 +21,65 @@ wifi:
 api:
 ota:
 
-logger:
-  esp8266_store_log_strings_in_flash: false
-
 output:
   - platform: esp8266_pwm
     pin: GPIO12
-    id: output_cw
+    id: out_cw
   - platform: esp8266_pwm
     pin: GPIO15
-    id: output_ww
+    id: out_b
 
 light:
-  - platform: custom
-    lambda: |-
-      auto light_out = new XiaomiLight(id(output_cw),id(output_ww));
-      App.register_component(light_out);
-      return {light_out};
-    lights:
-      - name: ${name}
-        id: bulb
+  - platform: custom 
+    lambda: |- 
+      auto light_out = new XiaomiLight(id(out_cw),id(out_b)); 
+      App.register_component(light_out); 
+      return {light_out}; 
+    lights: 
+      - name: $hostname Light
+        id: TheLight
         gamma_correct: 0
-        default_transition_length: 350ms
+
+sensor:
+  - platform: ntc
+    id: the_ntc
+    sensor: resistance_sensor
+    calibration:
+      b_constant: 3950
+      reference_temperature: 25°C
+      reference_resistance: 100000
+    name: "$hostname NTC Temperature"
+    on_value:
+      if:
+        condition:
+          light.is_on: TheLight
+        then:
+          lambda: |-
+            float brt; 
+            id(TheLight).current_values_as_brightness(&brt);
+            if (x > 55) {
+              brt -= 0.1;
+              auto cl = id(TheLight).turn_on();
+              cl.set_brightness(brt);
+              cl.perform();
+              ESP_LOGD("NTC", "Overheat! Decreasing brightness to %f", brt);
+            }
+  - platform: resistance
+    id: resistance_sensor
+    sensor: source_sensor
+    configuration: DOWNSTREAM
+    resistor: 500000
+    reference_voltage: 3.3
+    name: $hostname Resistance Sensor
+    internal: true
+  - platform: adc
+    name: "$hostname RAW ADC"
+    internal: true
+    id: source_sensor
+    pin: A0
+    update_interval: 60s
+    filters:
+      - median:
+          window_size: 3
+          send_every: 1
+          send_first_at: 1


### PR DESCRIPTION
Hi! It looks like your repository has the most most updated esphome config for these bulbs, so here goes my pull request: 
1. It looks like there's a thermistor on the ADC pin. I've added some guesstimates and added a failsafe to prevent overheat. The code will gradually reduce brightness every time the temperature is over 55 degrees.  The thermistor resistance, coefficient and divider resistor values are a pure guess, calibrated with my bare hands. Finding out actual value will require complete destruction of the bulb. Something I didn't want. 
2. It looks like cold white is never completely turned off from home assistant on my bulbs. The second patch fixes with by limiting cold white fraction to be no more than total brightness. 