### PR TITLE
Explicitly initialize all pointer members to nullptr

### DIFF
--- a/components/xiaomi_light/xiaomi_light.h
+++ b/components/xiaomi_light/xiaomi_light.h
@@ -48,8 +48,8 @@ class XiaomiLight : public Component, public light::LightOutput {
   }
 
  protected:
-  output::FloatOutput *cold_white_;
-  output::FloatOutput *brightness_;
+  output::FloatOutput *cold_white_{nullptr};
+  output::FloatOutput *brightness_{nullptr};
   float color_temperature_cw_;
   float color_temperature_ww_;
 };


### PR DESCRIPTION
## Summary
- Add `{nullptr}` in-class initializer to all raw pointer members in component header files that previously had no initializer
- Aligns with ESPHome core style: every component in the ESPHome core uses `{nullptr}` for pointer members — no uninitialized pointer exists in the core codebase
- While ESPHome instantiates components via `new T()` (value-initializes to zero), explicit `{nullptr}` makes the intent unambiguous and matches the upstream convention