### PR TITLE
Add missing CODEOWNERS to platform files

### DIFF
--- a/components/xiaomi_light/__init__.py
+++ b/components/xiaomi_light/__init__.py
@@ -2,6 +2,8 @@ import esphome.codegen as cg
 from esphome.components import light
 import esphome.config_validation as cv
 
+CODEOWNERS = ["@syssi"]
+
 xiaomi_light_ns = cg.esphome_ns.namespace("xiaomi_light")
 XiaomiLight = xiaomi_light_ns.class_("XiaomiLight", cg.Component, light.LightOutput)
 

--- a/components/xiaomi_light/light.py
+++ b/components/xiaomi_light/light.py
@@ -6,6 +6,7 @@ from esphome.const import CONF_BRIGHTNESS, CONF_COLD_WHITE, CONF_OUTPUT_ID
 from . import XiaomiLight
 
 DEPENDENCIES = ["output"]
+CODEOWNERS = ["@syssi"]
 
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
     {


### PR DESCRIPTION
Add `CODEOWNERS = ["@syssi"]` to `xiaomi_light/__init__.py` and `xiaomi_light/light.py` for consistency with other ESPHome components.