### PR TITLE
Use C++17 concatenated namespace syntax

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -96,7 +96,6 @@ Checks: >-
   -modernize-avoid-variadic-functions,
   -modernize-avoid-c-arrays,
   -modernize-avoid-c-style-cast,
-  -modernize-concat-nested-namespaces,
   -modernize-macro-to-enum,
   -modernize-return-braced-init-list,
   -modernize-type-traits,

--- a/components/xiaomi_light/xiaomi_light.h
+++ b/components/xiaomi_light/xiaomi_light.h
@@ -4,8 +4,7 @@
 #include "esphome/components/light/light_output.h"
 #include "esphome/components/output/float_output.h"
 
-namespace esphome {
-namespace xiaomi_light {
+namespace esphome::xiaomi_light {
 
 class XiaomiLight : public Component, public light::LightOutput {
  public:
@@ -54,5 +53,4 @@ class XiaomiLight : public Component, public light::LightOutput {
   float color_temperature_ww_;
 };
 
-}  // namespace xiaomi_light
-}  // namespace esphome
+}  // namespace esphome::xiaomi_light


### PR DESCRIPTION
The `modernize-concat-nested-namespaces` check is active in ESPHome's CI. All nested namespace blocks are replaced with `namespace esphome::X` syntax. The `.clang-tidy` is synced to the current ESPHome dev version.